### PR TITLE
Golang面试题解析（四）第35题代码不严谨

### DIFF
--- a/content/interview/articles/interview_analysis_3.md
+++ b/content/interview/articles/interview_analysis_3.md
@@ -290,10 +290,9 @@ package main
 
 import (
     "fmt"
-    "reflect"
 )
 
-func main1()  {
+func main()  {
     defer func() {
        if err:=recover();err!=nil{
            fmt.Println(err)
@@ -304,25 +303,6 @@ func main1()  {
 
     defer func() {
         panic("defer panic")
-    }()
-    panic("panic")
-}
-
-func main()  {
-    defer func() {
-        if err:=recover();err!=nil{
-            fmt.Println("++++")
-            f:=err.(func()string)
-            fmt.Println(err,f(),reflect.TypeOf(err).Kind().String())
-        }else {
-            fmt.Println("fatal")
-        }
-    }()
-
-    defer func() {
-        panic(func() string {
-            return  "defer panic"
-        })
     }()
     panic("panic")
 }

--- a/content/interview/articles/interview_analysis_4.md
+++ b/content/interview/articles/interview_analysis_4.md
@@ -166,18 +166,19 @@ fatal error: stack overflow
 输入的整数要求是一个 32bit 有符号数，如果反转后溢出，则输出 0  
 
 ```
-func reverse(x int) (num int) {
-	for x != 0 {
-		num = num*10 + x%10
-		x = x / 10
+func reverse(x int32) int32 {
+	var num int64
+	x64 := int64(x)
+	for x64 != 0 {
+		num = num*10 + x64%10
+		x64 = x64 / 10
 	}
 	// 使用 math 包中定义好的最大最小值
 	if num > math.MaxInt32 || num < math.MinInt32 {
 		return 0
 	}
-	return
+	return int32(num)
 }
-
 ```
 
 ## 36，编程题


### PR DESCRIPTION
int类型是32或64位，与操作系统位数有关

```go
package main

import (
	"fmt"
	"math"
)

func reverse2(x int32) int32 {
	fmt.Println("num2:", x)
	var num int64
	x64 := int64(x)
	for x64 != 0 {
		num = num*10 + x64%10
		x64 = x64 / 10
	}
	// 使用 math 包中定义好的最大最小值
	if num > math.MaxInt32 || num < math.MinInt32 {
		return 0
	}
	return int32(num)
}

func reverse(x int) (num int) {
	fmt.Println("num:", x)
	for x != 0 {
		num = num*10 + x%10
		x = x / 10
	}
	// 使用 math 包中定义好的最大最小值
	if num > math.MaxInt32 || num < math.MinInt32 {
		return 0
	}
	return
}

func main() {
	var a int = 2147483647
	fmt.Println("reverse():", reverse(a))
	fmt.Println("reverse2():", reverse2(int32(a)))
	// ----------------- x86_64
	// num: 2147483647
	// reverse(): 0
	// num2: 2147483647
	// reverse2(): 0

	// ----------------- i686
	// num: 2147483647
	// reverse(): -1126087180
	// num2: 2147483647
	// reverse2(): 0
}
```