### PR TITLE
Change StarTrack-js URL to fit the new version

### DIFF
--- a/README.cht.md
+++ b/README.cht.md
@@ -14,7 +14,7 @@
 
 [![Stargazers over time](https://starcharts.herokuapp.com/developer-learning/reading-go.svg)](https://starcharts.herokuapp.com/developer-learning/reading-go)
 
-[reading-go Star History and Stats](https://seladb.github.io/StarTrack-js/#/preload?r=developer-learning,reading-go)
+[reading-go Star History and Stats](https://seladb.github.io/StarTrack-js/#/preload?r=developer-learning,night-reading-go)
 
 Go 學習與分享：
 

--- a/README.cht.md
+++ b/README.cht.md
@@ -14,7 +14,7 @@
 
 [![Stargazers over time](https://starcharts.herokuapp.com/developer-learning/reading-go.svg)](https://starcharts.herokuapp.com/developer-learning/reading-go)
 
-[reading-go Star History and Stats](https://seladb.github.io/StarTrack-js/?u=developer-learning&r=reading-go)
+[reading-go Star History and Stats](https://seladb.github.io/StarTrack-js/#/preload?r=developer-learning,reading-go)
 
 Go 學習與分享：
 

--- a/README.de.md
+++ b/README.de.md
@@ -14,7 +14,7 @@
 
 [![Stargazers Over Time](https://starcharts.herokuapp.com/developer-learning/reading-go.svg)](https://starcharts.herokuapp.com/developer-learning/reading-go)
 
-[reading-go Sternenhistory und Statistiken](https://seladb.github.io/StarTrack-js/?u=developer-learning&r=reading-go)
+[reading-go Sternenhistory und Statistiken](https://seladb.github.io/StarTrack-js/#/preload?r=developer-learning,reading-go)
 
 Go Studieren und Teilen:
 

--- a/README.de.md
+++ b/README.de.md
@@ -14,7 +14,7 @@
 
 [![Stargazers Over Time](https://starcharts.herokuapp.com/developer-learning/reading-go.svg)](https://starcharts.herokuapp.com/developer-learning/reading-go)
 
-[reading-go Sternenhistory und Statistiken](https://seladb.github.io/StarTrack-js/#/preload?r=developer-learning,reading-go)
+[reading-go Sternenhistory und Statistiken](https://seladb.github.io/StarTrack-js/#/preload?r=developer-learning,night-reading-go)
 
 Go Studieren und Teilen:
 

--- a/README.en.md
+++ b/README.en.md
@@ -14,7 +14,7 @@
 
 [![Stargazers Over Time](https://starcharts.herokuapp.com/developer-learning/reading-go.svg)](https://starcharts.herokuapp.com/developer-learning/reading-go)
 
-[reading-go Star History and Stats](https://seladb.github.io/StarTrack-js/?u=developer-learning&r=reading-go)
+[reading-go Star History and Stats](https://seladb.github.io/StarTrack-js/#/preload?r=developer-learning,reading-go)
 
 Go Learning and Sharing:
 

--- a/README.en.md
+++ b/README.en.md
@@ -14,7 +14,7 @@
 
 [![Stargazers Over Time](https://starcharts.herokuapp.com/developer-learning/reading-go.svg)](https://starcharts.herokuapp.com/developer-learning/reading-go)
 
-[reading-go Star History and Stats](https://seladb.github.io/StarTrack-js/#/preload?r=developer-learning,reading-go)
+[reading-go Star History and Stats](https://seladb.github.io/StarTrack-js/#/preload?r=developer-learning,night-reading-go)
 
 Go Learning and Sharing:
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![Stargazers over time](https://starcharts.herokuapp.com/developer-learning/night-reading-go.svg)](https://starcharts.herokuapp.com/developer-learning/night-reading-go)
 
-[night-reading-go Star History and Stats](https://seladb.github.io/StarTrack-js/?u=developer-learning&r=night-reading-go)
+[night-reading-go Star History and Stats](https://seladb.github.io/StarTrack-js/#/preload?r=developer-learning,night-reading-go)
 
 ## 怎样加入
 

--- a/content/index.md
+++ b/content/index.md
@@ -11,7 +11,7 @@ weight: 0
 
 [![Stargazers over time](https://starcharts.herokuapp.com/developer-learning/reading-go.svg)](https://starcharts.herokuapp.com/developer-learning/reading-go)
 
-[reading-go Star History and Stats](https://seladb.github.io/StarTrack-js/?u=developer-learning&r=reading-go)
+[reading-go Star History and Stats](https://seladb.github.io/StarTrack-js/#/preload?r=developer-learning,reading-go)
 
 Go 学习与分享：
 

--- a/content/index.md
+++ b/content/index.md
@@ -11,7 +11,7 @@ weight: 0
 
 [![Stargazers over time](https://starcharts.herokuapp.com/developer-learning/reading-go.svg)](https://starcharts.herokuapp.com/developer-learning/reading-go)
 
-[reading-go Star History and Stats](https://seladb.github.io/StarTrack-js/#/preload?r=developer-learning,reading-go)
+[reading-go Star History and Stats](https://seladb.github.io/StarTrack-js/#/preload?r=developer-learning,night-reading-go)
 
 Go 学习与分享：
 


### PR DESCRIPTION
The current URL doesn't work with the new StarTrack-js version (2.x) so I've change it to fit the new version